### PR TITLE
[EPLAY-708] update normalize-url to newest package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "get-urls",
-	"version": "10.0.1",
+	"version": "10.1.1",
 	"description": "Get all URLs in a string",
 	"license": "MIT",
 	"repository": "sindresorhus/get-urls",
@@ -31,7 +31,7 @@
 		"string"
 	],
 	"dependencies": {
-		"normalize-url": "^5.1.0",
+		"normalize-url": "^7.0.2",
 		"url-regex-safe": "^2.0.2"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Update `normalize-url` to version `7.0.2` to fix Safari not supporting look behind.